### PR TITLE
Implement local task cache

### DIFF
--- a/src/components/DailyTasks/DailyTasks.controller.ts
+++ b/src/components/DailyTasks/DailyTasks.controller.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useAuth } from "../../context/AuthContext";
 import { getTaskLogByDate, deleteTaskLog, addTaskLog, getTaskLogsByMonth, getTaskLogsByYear, getTaskLogDaysByMonth, getTaskLogDaysByYear, getTaskStreak } from "../../service/taskLogService";
 import { getTasks, archiveTask, ensureTaskPeriodIsCurrent, ensureTaskYearIsCurrent, updateTask, updateTaskPriority } from "../../service/taskService";
+import { getTaskCache, setTaskCache } from "../../utils/taskCache";
 import type { Task } from "../../types/Task";
 import { getDailyCounter, incrementDailyCounter, updateDailyComment, getMonthlyDays, getYearlyDays } from "../../service/counterService";
 import type { SeverityType } from "../shared/SharedSnackbar";
@@ -101,16 +102,37 @@ export const useDailyTasksController = () => {
         if (!user) return;
         setLoading(true);
 
-        let userTasks = await getTasks(user.uid, false);
+        const cachedData = getTaskCache();
+        let userTasks: Task[] = [];
+        let shouldRefreshFromFirebase = false;
 
+        if (cachedData && !cachedData.needsUpdate) {
+            userTasks = cachedData.tasks;
 
-        for (const t of userTasks) {
-            await ensureTaskPeriodIsCurrent(user.uid, t);
-            await ensureTaskYearIsCurrent(user.uid, t);
+            // Check if periods need updating even with cached data
+            for (const t of userTasks) {
+                const periodChanged = await ensureTaskPeriodIsCurrent(user.uid, t);
+                const yearChanged = await ensureTaskYearIsCurrent(user.uid, t);
+                if (periodChanged || yearChanged) {
+                    shouldRefreshFromFirebase = true;
+                }
+            }
+
+            if (shouldRefreshFromFirebase) {
+                userTasks = await getTasks(user.uid, false);
+                setTaskCache(userTasks);
+            }
+        } else {
+            userTasks = await getTasks(user.uid, false);
+
+            for (const t of userTasks) {
+                await ensureTaskPeriodIsCurrent(user.uid, t);
+                await ensureTaskYearIsCurrent(user.uid, t);
+            }
+
+            userTasks = await getTasks(user.uid, false);
+            setTaskCache(userTasks);
         }
-
-
-        userTasks = await getTasks(user.uid, false);
 
 
         userTasks.sort((a, b) => {

--- a/src/service/taskService.ts
+++ b/src/service/taskService.ts
@@ -14,6 +14,7 @@ import {
 } from "firebase/firestore";
 import type { Task } from "../types/Task";
 import { getNowInBrasilia, getPeriodStartForType } from "../utils/period";
+import { invalidateTaskCache } from "../utils/taskCache";
 
 
 export async function addTask(userId: string, task: Task) {
@@ -32,6 +33,7 @@ export async function addTask(userId: string, task: Task) {
         totalMonth: 0,
         totalYear: 0,
     });
+    invalidateTaskCache();
 }
 
 
@@ -62,6 +64,7 @@ export async function getTasks(userId: string, includeArchived = false): Promise
 export async function updateTask(userId: string, taskId: string, updates: Partial<Task>) {
     const taskRef = doc(db, "users", userId, "tasks", taskId);
     await updateDoc(taskRef, updates);
+    invalidateTaskCache();
 }
 
 
@@ -69,6 +72,7 @@ export async function updateTaskPriority(userId: string, taskId: string, isPrior
     const taskRef = doc(db, "users", userId, "tasks", taskId);
     const priorityValue = isPriority ? Timestamp.now() : null;
     await updateDoc(taskRef, { priority: priorityValue });
+    invalidateTaskCache();
 }
 
 
@@ -113,6 +117,7 @@ export async function ensureTaskYearIsCurrent(userId: string, task: Task): Promi
 export async function archiveTask(userId: string, taskId: string) {
     const taskRef = doc(db, "users", userId, "tasks", taskId);
     await updateDoc(taskRef, { archived: true });
+    invalidateTaskCache();
 }
 
 
@@ -120,6 +125,7 @@ export async function deleteTaskPermanently(userId: string, taskId: string) {
 
     const taskRef = doc(db, "users", userId, "tasks", taskId);
     await deleteDoc(taskRef);
+    invalidateTaskCache();
 
 
     const logsRef = collection(db, "users", userId, "taskLogs");

--- a/src/utils/taskCache.ts
+++ b/src/utils/taskCache.ts
@@ -1,4 +1,4 @@
-import { Task } from "../types/Task";
+import type { Task } from "../types/Task";
 
 const CACHE_KEY = "app_tasks_data";
 

--- a/src/utils/taskCache.ts
+++ b/src/utils/taskCache.ts
@@ -1,0 +1,41 @@
+import { Task } from "../types/Task";
+
+const CACHE_KEY = "app_tasks_data";
+
+interface TaskCache {
+    tasks: Task[];
+    needsUpdate: boolean;
+}
+
+export const getTaskCache = (): TaskCache | null => {
+    const cachedData = localStorage.getItem(CACHE_KEY);
+    if (!cachedData) return null;
+    try {
+        return JSON.parse(cachedData);
+    } catch (e) {
+        console.error("Error parsing task cache", e);
+        return null;
+    }
+};
+
+export const setTaskCache = (tasks: Task[]) => {
+    const cacheData: TaskCache = {
+        tasks,
+        needsUpdate: false,
+    };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
+};
+
+export const invalidateTaskCache = () => {
+    const cachedData = getTaskCache();
+    if (cachedData) {
+        cachedData.needsUpdate = true;
+        localStorage.setItem(CACHE_KEY, JSON.stringify(cachedData));
+    } else {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ tasks: [], needsUpdate: true }));
+    }
+};
+
+export const clearTaskCache = () => {
+    localStorage.removeItem(CACHE_KEY);
+};

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -3,6 +3,7 @@ import { GoogleAuthProvider, signInWithPopup, signOut } from "firebase/auth";
 import { setPersistence, browserLocalPersistence } from "firebase/auth";
 import { auth } from "../firebase/config";
 import GoogleIcon from '@mui/icons-material/Google';
+import { clearTaskCache } from "../utils/taskCache";
 import {
     Box, Button, Typography,
     Avatar,
@@ -25,6 +26,7 @@ function App() {
 
     const handleLogout = async () => {
         await signOut(auth);
+        clearTaskCache();
     };
 
     if (loading) return <LoadingScreen />

--- a/versioning.ts
+++ b/versioning.ts
@@ -1,2 +1,2 @@
 
-export const version = 'v-0.17.9'
+export const version = 'v-1.0.0'


### PR DESCRIPTION
Implemented a local caching system for tasks to improve performance and reduce Firebase reads. The system uses a `needsUpdate` flag for invalidation and ensures data remains fresh by checking period/year resets even when loading from cache. The cache is cleared upon user logout.

---
*PR created automatically by Jules for task [7730286928142212014](https://jules.google.com/task/7730286928142212014) started by @pedro-belarmino*