### PR TITLE
Add one-time welcome modal for new non-authorized users

### DIFF
--- a/src/components/shared/WelcomeModal.tsx
+++ b/src/components/shared/WelcomeModal.tsx
@@ -1,0 +1,50 @@
+import { Dialog, DialogContent, DialogActions, Button, Typography, Box } from "@mui/material";
+
+interface WelcomeModalProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export default function WelcomeModal({ open, onClose }: WelcomeModalProps) {
+    return (
+        <Dialog
+            open={open}
+            onClose={(_, reason) => {
+                // Prevent closing by clicking outside or pressing escape
+                if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
+                    onClose();
+                }
+            }}
+            PaperProps={{
+                sx: {
+                    borderRadius: 3,
+                    p: 2,
+                    textAlign: 'center'
+                }
+            }}
+        >
+            <DialogContent>
+                <Box display="flex" flexDirection="column" alignItems="center" gap={3}>
+                    <img
+                        src="/logo_semfundo.png"
+                        alt="Logo"
+                        style={{ width: 80, maxWidth: "100%" }}
+                    />
+                    <Typography variant="body1" sx={{ fontWeight: 500, lineHeight: 1.6 }}>
+                        Você está acessando uma ferramenta gratuita para aprender a treinar o Agradecimento e descobrir o poder que essa prática diária tem de equilibrar os principais pilares da sua vida.
+                    </Typography>
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ justifyContent: 'center', pb: 3 }}>
+                <Button
+                    variant="contained"
+                    color="warning"
+                    onClick={onClose}
+                    sx={{ px: 4, py: 1, borderRadius: 2, fontWeight: 'bold' }}
+                >
+                    Começar a agradecer!
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,6 +10,8 @@ type AuthContextType = {
     loading: boolean;
     isAuthorized: boolean;
     isAuthorizedPartial: boolean;
+    showWelcomeModal: boolean;
+    markWelcomeModalAsSeen: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextType>({
@@ -17,13 +19,24 @@ const AuthContext = createContext<AuthContextType>({
     loading: true,
     isAuthorized: false,
     isAuthorizedPartial: false,
+    showWelcomeModal: false,
+    markWelcomeModalAsSeen: async () => { },
 });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
     const [isAuthorized, setIsAuthorized] = useState(false);
     const [isAuthorizedPartial, setIsAuthorizedPartial] = useState(false);
+    const [showWelcomeModal, setShowWelcomeModal] = useState(false);
     const [loading, setLoading] = useState(true);
+
+    const markWelcomeModalAsSeen = async () => {
+        if (user) {
+            const userRef = doc(db, "users", user.uid);
+            await setDoc(userRef, { hasSeenWelcomeModal: true }, { merge: true });
+            setShowWelcomeModal(false);
+        }
+    };
 
     useEffect(() => {
         const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
@@ -46,7 +59,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
                         email: currentUser.email,
                         photoURL: currentUser.photoURL,
                         createdAt: Timestamp.now(),
+                        hasSeenWelcomeModal: false,
                     });
+
+                    if (!authorized && !authorizedPartial) {
+                        setShowWelcomeModal(true);
+                    }
+                } else {
+                    const userData = snapshot.data();
+                    if (!authorized && !authorizedPartial && userData.hasSeenWelcomeModal === false) {
+                        setShowWelcomeModal(true);
+                    }
                 }
 
                 setUser(currentUser);
@@ -63,7 +86,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }, []);
 
     return (
-        <AuthContext.Provider value={{ user, loading, isAuthorized, isAuthorizedPartial }}>
+        <AuthContext.Provider value={{
+            user,
+            loading,
+            isAuthorized,
+            isAuthorizedPartial,
+            showWelcomeModal,
+            markWelcomeModalAsSeen
+        }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -11,11 +11,12 @@ import {
 import { useNavigate } from "react-router-dom";
 import { version } from '../../versioning'
 import LoadingScreen from "./LoadingScreen";
+import WelcomeModal from "../components/shared/WelcomeModal";
 
 function App() {
 
     const navigate = useNavigate()
-    const { user, loading } = useAuth();
+    const { user, loading, showWelcomeModal, markWelcomeModalAsSeen } = useAuth();
 
     const handleLogin = async () => {
         const provider = new GoogleAuthProvider();
@@ -28,6 +29,11 @@ function App() {
     };
 
     if (loading) return <LoadingScreen />
+
+    const handleWelcomeModalClose = async () => {
+        await markWelcomeModalAsSeen();
+        navigate('/home');
+    };
 
     return (
         <Card
@@ -129,6 +135,11 @@ function App() {
                 )}
             </CardActions>
             <p style={{ fontSize: 'small', }}>{version}</p>
+
+            <WelcomeModal
+                open={showWelcomeModal}
+                onClose={handleWelcomeModalClose}
+            />
         </Card>
     );
 }


### PR DESCRIPTION
This change implements a one-time welcome modal that appears immediately after Google login for users who are logging in for the first time and are not present in the `authorizedEmails` or `authorizedEmailsPartial` collections.

Key changes:
1.  **New Component**: Added `WelcomeModal.tsx` in `src/components/shared/` to display the specific message and the "Começar a agradecer!" button.
2.  **AuthContext Update**: Added `showWelcomeModal` and `hasSeenWelcomeModal` logic to the authentication context. It now tracks whether a user has seen the modal by persisting this state in their Firestore user document.
3.  **Login View Integration**: The `Login.tsx` view now listens for the `showWelcomeModal` state and renders the modal when necessary. It also handles the transition to the Home screen upon dismissal.
4.  **Firestore Schema**: User documents now include a `hasSeenWelcomeModal` boolean field.

This ensures that only users who are not part of the mentorship programs (authorized lists) see the introductory message about the free tool, and they only see it once.

---
*PR created automatically by Jules for task [3409855597420721245](https://jules.google.com/task/3409855597420721245) started by @pedro-belarmino*