### PR TITLE
Fix Infinite Loading Screen Bug

### DIFF
--- a/src/components/ArchivedTasksList/ArchivedTasksList.controller.ts
+++ b/src/components/ArchivedTasksList/ArchivedTasksList.controller.ts
@@ -30,9 +30,14 @@ export function useArchivedTasksListController() {
             setLoading(true);
         }
 
-        const userTasks = await getTasks(user.uid, true, forceRefresh);
-        setArchivedTasks(userTasks.filter((task) => task.archived));
-        setLoading(false);
+        try {
+            const userTasks = await getTasks(user.uid, true, forceRefresh);
+            setArchivedTasks(userTasks.filter((task) => task.archived));
+        } catch (error) {
+            console.error("Error fetching archived tasks:", error);
+        } finally {
+            setLoading(false);
+        }
     };
 
     useEffect(() => {

--- a/src/components/DailyTasks/DailyTasks.controller.ts
+++ b/src/components/DailyTasks/DailyTasks.controller.ts
@@ -104,34 +104,43 @@ export const useDailyTasksController = () => {
         if (!user) return;
         setLoading(true);
 
-        let userTasks = await getTasks(user.uid, false, forceRefresh);
-        for (const t of userTasks) {
-            await ensureTaskPeriodIsCurrent(user.uid, t);
-            await ensureTaskYearIsCurrent(user.uid, t);
+        try {
+            let userTasks = await getTasks(user.uid, false, forceRefresh);
+            for (const t of userTasks) {
+                try {
+                    await ensureTaskPeriodIsCurrent(user.uid, t);
+                    await ensureTaskYearIsCurrent(user.uid, t);
+                } catch (err) {
+                    console.error(`Error ensuring period/year is current for task ${t.id}:`, err);
+                }
+            }
+            userTasks = await getTasks(user.uid, false, forceRefresh);
+
+            userTasks.sort((a, b) => {
+                if (a.priority && !b.priority) return -1;
+                if (!a.priority && b.priority) return 1;
+                if (a.priority && b.priority) return b.priority.toMillis() - a.priority.toMillis();
+                const [ah, am] = a.schedule.split(":").map(Number);
+                const [bh, bm] = b.schedule.split(":").map(Number);
+                return ah * 60 + am - (bh * 60 + bm);
+            });
+
+            setTasks(userTasks);
+
+            const now = getNowInBrasilia();
+            const today = formatISODate(now);
+            const logsToday = await getTaskLogsByDay(user.uid, today);
+            const status: Record<string, string | null> = {};
+            for (const task of userTasks) {
+                const log = logsToday.find(l => l.taskId === task.id);
+                status[task.id!] = log ? log.id! : null;
+            }
+            setDoneToday(status);
+        } catch (error) {
+            console.error("Error fetching tasks in DailyTasks.controller:", error);
+        } finally {
+            setLoading(false);
         }
-        userTasks = await getTasks(user.uid, false, forceRefresh);
-
-        userTasks.sort((a, b) => {
-            if (a.priority && !b.priority) return -1;
-            if (!a.priority && b.priority) return 1;
-            if (a.priority && b.priority) return b.priority.toMillis() - a.priority.toMillis();
-            const [ah, am] = a.schedule.split(":").map(Number);
-            const [bh, bm] = b.schedule.split(":").map(Number);
-            return ah * 60 + am - (bh * 60 + bm);
-        });
-
-        setTasks(userTasks);
-
-        const now = getNowInBrasilia();
-        const today = formatISODate(now);
-        const logsToday = await getTaskLogsByDay(user.uid, today);
-        const status: Record<string, string | null> = {};
-        for (const task of userTasks) {
-            const log = logsToday.find(l => l.taskId === task.id);
-            status[task.id!] = log ? log.id! : null;
-        }
-        setDoneToday(status);
-        setLoading(false);
     };
 
     // Ao mudar filtro ou tasks: recalcula filteredTasks e reseta para página 1

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -40,46 +40,63 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
     useEffect(() => {
         const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-            if (currentUser && currentUser.email) {
-                const [authorized, authorizedPartial] = await Promise.all([
-                    isEmailAuthorized(currentUser.email),
-                    isEmailAuthorizedPartial(currentUser.email)
-                ]);
+            try {
+                if (currentUser && currentUser.email) {
+                    let authorized = false;
+                    let authorizedPartial = false;
 
-                setIsAuthorized(authorized);
-                setIsAuthorizedPartial(authorizedPartial);
-
-                const userRef = doc(db, "users", currentUser.uid);
-                const snapshot = await getDoc(userRef);
-
-                if (!snapshot.exists()) {
-                    await setDoc(userRef, {
-                        uid: currentUser.uid,
-                        displayName: currentUser.displayName,
-                        email: currentUser.email,
-                        photoURL: currentUser.photoURL,
-                        createdAt: Timestamp.now(),
-                        hasSeenWelcomeModal: false,
-                    });
-
-                    if (!authorized && !authorizedPartial) {
-                        setShowWelcomeModal(true);
+                    try {
+                        const [authResult, authPartialResult] = await Promise.all([
+                            isEmailAuthorized(currentUser.email),
+                            isEmailAuthorizedPartial(currentUser.email)
+                        ]);
+                        authorized = authResult;
+                        authorizedPartial = authPartialResult;
+                    } catch (error) {
+                        console.error("Error checking email authorization:", error);
                     }
+
+                    setIsAuthorized(authorized);
+                    setIsAuthorizedPartial(authorizedPartial);
+
+                    try {
+                        const userRef = doc(db, "users", currentUser.uid);
+                        const snapshot = await getDoc(userRef);
+
+                        if (!snapshot.exists()) {
+                            await setDoc(userRef, {
+                                uid: currentUser.uid,
+                                displayName: currentUser.displayName,
+                                email: currentUser.email,
+                                photoURL: currentUser.photoURL,
+                                createdAt: Timestamp.now(),
+                                hasSeenWelcomeModal: false,
+                            });
+
+                            if (!authorized && !authorizedPartial) {
+                                setShowWelcomeModal(true);
+                            }
+                        } else {
+                            const userData = snapshot.data();
+                            if (!authorized && !authorizedPartial && userData.hasSeenWelcomeModal === false) {
+                                setShowWelcomeModal(true);
+                            }
+                        }
+                    } catch (error) {
+                        console.error("Error updating or retrieving user document in AuthContext:", error);
+                    }
+
+                    setUser(currentUser);
                 } else {
-                    const userData = snapshot.data();
-                    if (!authorized && !authorizedPartial && userData.hasSeenWelcomeModal === false) {
-                        setShowWelcomeModal(true);
-                    }
+                    setUser(null);
+                    setIsAuthorized(false);
+                    setIsAuthorizedPartial(false);
                 }
-
-                setUser(currentUser);
-            } else {
-                setUser(null);
-                setIsAuthorized(false);
-                setIsAuthorizedPartial(false);
+            } catch (error) {
+                console.error("Critical error in onAuthStateChanged hook:", error);
+            } finally {
+                setLoading(false);
             }
-
-            setLoading(false);
         });
 
         return () => unsubscribe();


### PR DESCRIPTION
This change introduces robust try-catch-finally error handling to AuthContext, DailyTasks.controller, and ArchivedTasksList.controller. Previously, if any Firestore promise rejected (for example, due to permission issues, offline conditions, or query failures), execution would halt before `setLoading(false)` was reached, leaving the application hanging indefinitely in a LoadingScreen state. The changes ensure that setLoading(false) is guaranteed to execute in all scenarios.

---
*PR created automatically by Jules for task [10872370560251334885](https://jules.google.com/task/10872370560251334885) started by @pedro-belarmino*